### PR TITLE
- [build](Makefile) Due to changed behavior with docker 26, files are…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.8
+
+- [build](Makefile) Due to changed behavior with docker 26, files are now copied on the host instead of being hard-linked.
+- [build](Makefile) Now set `BLD_CVER ?= ast200` to match codec and asterisk versions.
+- [demo](demo/docker-compose.yml) Remove obsolete element `version` in docker-compose.yml.
+
 # 1.1.7
 
 - [build](Makefile) Now use alpine:3.19 (asterisk:20.5.2).

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ BLD_VER  ?= latest
 BLD_TGT  ?= full
 BLD_TGTS ?= mini base full xtra
 BLD_CMT  ?= HEAD
-BLD_CVER ?= ast160
+BLD_CVER ?= ast200
 BLD_DNLD ?= curl -o
 BLD_KIT  ?= DOCKER_BUILDKIT=1
 
@@ -53,14 +53,14 @@ pre_codecs: codec_g723.so codec_g729.so
 
 sub/autoban/php/ami.class.inc: submodule
 	mkdir -p $(@D)
-	ln -f sub/module/phpami/src/Ami.php $@
+	cp --remove-destination sub/module/phpami/src/Ami.php $@
 
 submodule:
 	git submodule update --init --recursive
 
 codec_%.so: sub/codecs/download/codec_%-$(BLD_CVER).so
 	mkdir -p sub/codecs/module
-	ln -f $< sub/codecs/module/$@
+	cp --remove-destination $< sub/codecs/module/$@
 
 .PRECIOUS: sub/codecs/download/%.so
 

--- a/demo/docker-compose.yml
+++ b/demo/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+name: demo
 
 services:
   tele:


### PR DESCRIPTION
… now copied on the host instead of being hard-linked.

- [build](Makefile) Now set `BLD_CVER ?= ast200` to match codec and asterisk versions.
- [demo](demo/docker-compose.yml) Remove obsolete element `version` in docker-compose.yml.